### PR TITLE
Fixed onLoadFinished bug and extended evaluate method

### DIFF
--- a/bridge.js
+++ b/bridge.js
@@ -59,8 +59,11 @@ controlpage.onAlert=function(msg){
 		var page=pages[id];
 		switch(request[2]){
 		case 'pageOpen':
-			page.open(request[3],function(status){
-				respond([id,cmdId,'pageOpened',status]);
+			page.open(request[3]);
+			break;
+		case 'pageOpenWithCallback':
+			page.open(request[3], function(status){
+				respond([id, cmdId, 'pageOpened', status]);
 			});
 			break;
 		case 'pageRelease':

--- a/bridge.js
+++ b/bridge.js
@@ -87,7 +87,7 @@ controlpage.onAlert=function(msg){
 			respond([id,cmdId,'pageFileUploaded']);
 			break;
 		case 'pageEvaluate':
-			var result=page.evaluate(request[3]);
+			var result=page.evaluate.apply(page, request.slice(3));
 			respond([id,cmdId,'pageEvaluated',JSON.stringify(result)]);
 			break;
 		case 'pageRender':

--- a/node-phantom.js
+++ b/node-phantom.js
@@ -87,8 +87,15 @@ module.exports={
 						uploadFile:function(selector,filename,callback){
 							request(socket,[id,'pageUploadFile',selector,filename],callbackOrDummy(callback));
 						},
-						evaluate:function(evaluator,callback){
-							request(socket,[id,'pageEvaluate',evaluator.toString()],callbackOrDummy(callback));
+						evaluate:function(evaluator){
+							var callback,
+								args = Array.prototype.slice.call(arguments, 1);
+
+							if(args.length > 0 && typeof args[args.length - 1] === 'function'){
+								callback = args.pop();
+							}
+							args = [id, 'pageEvaluate', evaluator.toString()].concat(args);
+							request(socket, args, callbackOrDummy(callback))
 						},
 						set:function(name,value,callback){
 							request(socket,[id,'pageSet',name,value],callbackOrDummy(callback));

--- a/node-phantom.js
+++ b/node-phantom.js
@@ -37,7 +37,7 @@ module.exports={
 				};\n\
 			</script></head><body></body></html>');
 		}).listen();
-		
+
 		var port=server.address().port;
 		var phantom=spawnPhantom(port);
 		var pages={};
@@ -62,8 +62,12 @@ module.exports={
 				switch(response[2]){
 				case 'pageCreated':
 					var pageProxy={
-						open:function(url,callback){
-							request(socket,[id,'pageOpen',url],callbackOrDummy(callback));
+						open:function(url, callback){
+							if(callback === undefined){
+								request(socket, [id, 'pageOpen', url]);
+							}else{
+								request(socket, [id, 'pageOpenWithCallback', url], callback);
+							}
 						},
 						release:function(callback){
 							request(socket,[id,'pageRelease'],callbackOrDummy(callback));
@@ -111,7 +115,9 @@ module.exports={
 					break;
 				case 'pageOpened':
 					if(cmds[cmdId]!==undefined){	//if page is redirected, the pageopen event is called again - we do not want that currently.
-						cmds[cmdId].cb(null,response[3]);
+						if(cmds[cmdId].cb !== undefined){
+							cmds[cmdId].cb(null, response[3]);
+						}
 						delete cmds[cmdId];
 					}
 					break;

--- a/test/testpagepushnotifications.js
+++ b/test/testpagepushnotifications.js
@@ -35,13 +35,21 @@ exports.testPhantomPagePushNotifications = function(beforeExit,assert) {
 					assert.match(err[0], /variable: conXsole/);
 					assert.equal(err[1][0].line, 1);
 
-					ph.createPage(errOr(function(page){
-						page.onLoadFinished = function(){
-							onLoadFinishedFired = true;
-							server.close();
-							ph.exit();
-						};
-						page.open(url);
+					events.onConsoleMessage = [];
+					page.evaluate(function(a,b){
+						console.log(a);
+						console.log(b);
+					}, 'A', 'B', errOr(function(){
+						assert.eql(events.onConsoleMessage, ['A', 'B']);
+
+						ph.createPage(errOr(function(page){
+							page.onLoadFinished = function(){
+								onLoadFinishedFired = true;
+								server.close();
+								ph.exit();
+							};
+							page.open(url);
+						}));
 					}));
 				}));
 			}));


### PR DESCRIPTION
I had the same issue as jfeldstein (https://github.com/alexscheelmeyer/node-phantom/issues/6#issuecomment-8874091) so I branched the logic in the open method based on whether a callback is provided.  The bridge now either gets a "pageOpen" or "pageOpenWithCallback" request so it can open the page with or without a callback.  I had to do this because always opening a page with a callback seems to block the onLoadFinished callback from being called.

I also extended the evaluate method to accept 0 or more arguments to pass to the function being evaluated.
