### PR TITLE
Fix `onLoadFinished` issues after `page.open`

### DIFF
--- a/bridge.js
+++ b/bridge.js
@@ -61,6 +61,8 @@ controlpage.onAlert=function(msg){
 		case 'pageOpen':
 			page.open(request[3],function(status){
 				respond([id,cmdId,'pageOpened',status]);
+				// Restore the onLoadFinished handler, was overwritten by page.open
+				setupPushNotifications(id, page);
 			});
 			break;
 		case 'pageRelease':

--- a/node-phantom.js
+++ b/node-phantom.js
@@ -63,6 +63,7 @@ module.exports={
 				case 'pageCreated':
 					var pageProxy={
 						open:function(url,callback){
+							if(callback===undefined)callback=pages[id]['onLoadFinished'];
 							request(socket,[id,'pageOpen',url],callbackOrDummy(callback));
 						},
 						release:function(callback){


### PR DESCRIPTION
When calling `page.open` with a callback (as in bridge.js), PhantomJS
overwrites `page.onLoadFinished` and never restores it.

This is the smallest change I could come up with to solve this issue -
it re-registers all event listeners after `page.open` returns, and if
`page.open` was called without a callback then it automatically forwards
the `onLoadFinished` event instead.

NOTE: I've deliberately not triggered `onLoadFinished` for all
`page.open` events so as to mimic PhantomJS's API (where it is one or
the other).
