### PR TITLE
Client-side page callback support

### DIFF
--- a/bridge.js
+++ b/bridge.js
@@ -99,7 +99,9 @@ controlpage.onAlert=function(msg){
 			var result=page[request[3]];
 			respond([id,cmdId,'pageGetDone',JSON.stringify(result)]);
 			break;
-
+		case 'pageSetFn':
+			page[request[3]] = eval('(' + request[4] + ')')
+			break;
 		default:
 			console.error('unrecognized request:'+request);
 			break;

--- a/node-phantom.js
+++ b/node-phantom.js
@@ -91,8 +91,10 @@ module.exports={
 						},
 						get:function(name,callback){
 							request(socket,[id,'pageGet',name],callbackOrDummy(callback));
+						},
+						setFn: function(pageCallbackName, fn, callback) {
+							request(socket, [id, 'pageSetFn', pageCallbackName, fn.toString()], callbackOrDummy(callback));
 						}
-						
 					};
 					pages[id] = pageProxy;
 					cmds[cmdId].cb(null,pageProxy);

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Alex Scheel Meyer (http://www.linkedin.com/in/alexscheelmeyer)",
   "name": "node-phantom",
   "description": "bridge between node.js and PhantomJS",
-  "version": "0.1.2",
+  "version": "0.1.2-snapshot",
   "homepage": "https://github.com/alexscheelmeyer/node-phantom",
   "repository": {
     "type": "git",

--- a/test/testpagesetfn.js
+++ b/test/testpagesetfn.js
@@ -1,0 +1,32 @@
+var http = require('http');
+var phantom = require('../node-phantom');
+
+var server=http.createServer(function(request,response){
+	response.writeHead(200,{"Content-Type": "text/html"});
+	response.end('<html><head><script>console.log("handled on phantom-side")</script></head><body><h1>Hello World</h1></body></html>');
+}).listen();
+
+exports.testPhantomPageSetFn = function(beforeExit,assert) {
+	var url = 'http://localhost:'+server.address().port+'/';
+	phantom.create(errOr(function(ph){
+		ph.createPage(errOr(function(page){
+			var messageForwardedByOnConsoleMessage = undefined;
+			var localMsg = undefined;
+			page.onConsoleMessage = function(msg) { messageForwardedByOnConsoleMessage = msg; };
+			page.setFn('onCallback', function(msg) { localMsg = msg; page.onConsoleMessage(msg); });
+			page.open(url, errOr(function(){
+				assert.isUndefined(localMsg);
+				assert.equal(messageForwardedByOnConsoleMessage, "handled on phantom-side");
+				server.close();
+				ph.exit();
+			}));
+		}));
+	}));
+
+	function errOr(fn) {
+		return function(err, res) {
+			assert.ifError(err);
+			fn(res);
+		}
+	}
+};


### PR DESCRIPTION
Add possibility to register functions into the phantomjs page object which are fully evaluated client-side. This can be used to remove asynchronousness from phantom callbacks such as page.onCallback(), since the evaluation takes place synchronously inside phantom instead of via socket.io in node.
