### PR TITLE
Custom Path for PhantomJS

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,18 @@ phantom.create(function(err,ph) {
 
 You can also have a look at the test folder to see some examples of using the API.
 
+## V0.2.0
+
+You can pass a second variable to `create` to define a custom path to a phantomjs executable. Useful when used in conjunction with the [phantomjs package](https://npmjs.org/package/phantomjs), especially when deploying in a CI build environment.
+
+```coffee-script
+phantom = require 'node-phantom'
+phantom.create (err, ph)->
+  # do something with ph
+, 'some/path/to/phantom/executable'
+...
+```
+
 Other
 -----
 Made by Alex Scheel Meyer. Released to the public domain.

--- a/node-phantom.js
+++ b/node-phantom.js
@@ -13,9 +13,16 @@ function unwrapArray(arr) {
 }
 
 module.exports={
-	create:function(callback){
+	create:function(callback, phantomPath){
+		var _phantomPath;
+		
+		if (phantomPath != null) {
+			_phantomPath = phantomPath;
+		} else {
+			_phantomPath = 'phantomjs';
+		}
 		function spawnPhantom(port){
-			var phantom=child.spawn('phantomjs',[__dirname + '/bridge.js',port]);
+			var phantom=child.spawn(_phantomPath,[__dirname + '/bridge.js',port]);
 			phantom.stdout.on('data',function(data){
 				return console.log('phantom stdout: '+data);
 			});

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Alex Scheel Meyer (http://www.linkedin.com/in/alexscheelmeyer)",
   "name": "node-phantom",
   "description": "bridge between node.js and PhantomJS",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "homepage": "https://github.com/alexscheelmeyer/node-phantom",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Hi there. I must admit I'm new to this so I hope I'm not breaking any etiquette by requesting this fork.

Anyhoo, I've found this package hugely useful. It's so much nicer to work with Phantom this way.

We have a mixed development environment with a bunch of developers on either Windows or OSX and a continual build environment (TeamCity) hosted on an Amazon EC2 Ubuntu box. like I say - mixed.

Given the range of environments I need to support, I want to use the [PhantomJS package](https://npmjs.org/package/phantomjs) to make sure each dev, and the build server,  has the PhantomJS binary available. This will put the Phantom binary in their node_modules path. 

In order to support this, and still make use of node-phantom, I needed the option to use a custom path for Phantom. 

My usual code preference is coffee-script. And when invoking node-phantom with coffee-script, the extra, optional parameter is easy to add, and to read. Something like:

``` coffee
node-phantom.create (err, ph)->
   ph.createPage (err, page)->
   # do stuff to the page
,"path/to/phantom"
```

I think (hope) others may find this useful. Especially when dealing with such a mixed team of developers.

Here's the confession - > I haven't written any tests for this. At least not in this project. I've tested the hell out of it in my implementation. But it's a pretty innocuous change in the code. One line really. So hopefully you'll include it?

Thanks in advance
