### PR TITLE
Use NPM phantomjs

### DIFF
--- a/bridge.js
+++ b/bridge.js
@@ -16,8 +16,7 @@ var pageId=1;
 function setupPushNotifications(id, page) {
 	var callbacks = [
     'onAlert','onConfirm','onConsoleMessage','onError','onInitialized','onLoadFinished',
-    'onLoadStarted','onPrompt','onResourceRequested','onResourceReceived','onUrlChanged',
-    'onCallback'
+    'onLoadStarted','onPrompt','onResourceRequested','onResourceReceived','onUrlChanged'
   ];
 	callbacks.forEach(function(cb) {
 		page[cb] = function() { push([id, cb, Array.prototype.slice.call(arguments)]); }

--- a/bridge.js
+++ b/bridge.js
@@ -16,7 +16,8 @@ var pageId=1;
 function setupPushNotifications(id, page) {
 	var callbacks = [
     'onAlert','onConfirm','onConsoleMessage','onError','onInitialized','onLoadFinished',
-    'onLoadStarted','onPrompt','onResourceRequested','onResourceReceived','onUrlChanged'
+    'onLoadStarted','onPrompt','onResourceRequested','onResourceReceived','onUrlChanged',
+    'onCallback'
   ];
 	callbacks.forEach(function(cb) {
 		page[cb] = function() { push([id, cb, Array.prototype.slice.call(arguments)]); }

--- a/node-phantom.js
+++ b/node-phantom.js
@@ -15,7 +15,7 @@ function unwrapArray(arr) {
 module.exports={
 	create:function(callback){
 		function spawnPhantom(port){
-			var phantom=child.spawn('phantomjs',[__dirname + '/bridge.js',port]);
+			var phantom=child.spawn(require('phantomjs').path,[__dirname + '/bridge.js',port]);
 			phantom.stdout.on('data',function(data){
 				return console.log('phantom stdout: '+data);
 			});

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "scripts": {
     "test": "expresso"
   },
-  "dependencies": {"socket.io": ">=0.9.6"},
+  "dependencies": {"socket.io": ">=0.9.6", "phantomjs": "*"},
   "devDependencies": {"socket.io": ">=0.9.2"},
   "optionalDependencies": {},
   "engines": {


### PR DESCRIPTION
The package https://npmjs.org/package/phantomjs allows you to not require `phantomjs` be present in the calling path.  This pull request would make node-phantom much easier to use, as it removes external dependencies.  Combined with #19, one could override the bin path if the phantomjs package bin is unsuitable.
