### PR TITLE
When calling exit(), added call to phantom.kill()

### DIFF
--- a/node-phantom.js
+++ b/node-phantom.js
@@ -150,6 +150,7 @@ module.exports={
 				},
 				exit:function(callback){
 					request(socket,[0,'exit'],callbackOrDummy(callback));
+					phantom.kill('SIGTERM');
 				}
 			};
 			


### PR DESCRIPTION
Calling exit() doesn't terminate the spawned process.  So I added a call to phantom.kill() to do the trick.  

Fixes #24
