### PR TITLE
Add support for page.rederBase64(format)

### DIFF
--- a/bridge.js
+++ b/bridge.js
@@ -91,6 +91,10 @@ controlpage.onAlert=function(msg){
 			page.render(request[3]);
 			respond([id,cmdId,'pageRendered']);
 			break;
+		case 'pageRenderBase64':
+			var result=page.renderBase64(request[3]);
+			respond([id,cmdId,'pageRenderBase64Done', result]);
+			break;
 		case 'pageSet':
 			page[request[3]]=request[4];
 			respond([id,cmdId,'pageSetDone']);

--- a/node-phantom.js
+++ b/node-phantom.js
@@ -71,6 +71,9 @@ module.exports={
 						render:function(filename,callback){
 							request(socket,[id,'pageRender',filename],callbackOrDummy(callback));
 						},
+						renderBase64:function(extension,callback){
+							request(socket,[id,'pageRenderBase64',extension],callbackOrDummy(callback));
+						},
 						injectJs:function(url,callback){
 							request(socket,[id,'pageInjectJs',url],callbackOrDummy(callback));
 						},
@@ -114,6 +117,10 @@ module.exports={
 						cmds[cmdId].cb(null,response[3]);
 						delete cmds[cmdId];
 					}
+					break;
+				case 'pageRenderBase64Done':
+					cmds[cmdId].cb(null,response[3]);
+					delete cmds[cmdId];
 					break;
 				case 'pageGetDone':
 				case 'pageEvaluated':

--- a/test/testpagerenderbase64.js
+++ b/test/testpagerenderbase64.js
@@ -1,0 +1,43 @@
+var http=require('http');
+var phantom=require('../node-phantom');
+var fs=require('fs');
+var crypto = require('crypto');
+
+function fileHash(filename){
+	var shasum=crypto.createHash('sha256');
+	var f=fs.readFileSync(filename);
+	shasum.update(f);
+	return shasum.digest('hex');
+}
+
+function bufferHash(buffer){
+	var shasum=crypto.createHash('sha256');
+	shasum.update(buffer);
+	return shasum.digest('hex');	
+}
+
+var server=http.createServer(function(request,response){
+	response.writeHead(200,{"Content-Type": "text/html"});
+	response.end('<html><head></head><body>Hello World</body></html>');
+}).listen();
+
+var verifyFilename=__dirname+'/files/verifyrender.png';
+
+exports.testPhantomPageRenderBase64=function(beforeExit,assert){
+	phantom.create(function(error,ph){
+		assert.ifError(error);
+		ph.createPage(function(err,page){
+			assert.ifError(err);
+			page.open('http://localhost:'+server.address().port,function(err,status){
+				assert.ifError(err);
+				assert.equal(status,'success');
+				page.renderBase64('png',function(err, imagedata){
+					assert.ifError(err);
+					assert.equal(bufferHash(new Buffer(imagedata, 'base64')),fileHash(verifyFilename));
+					server.close();
+					ph.exit();
+				});
+			});
+		});
+	});
+};


### PR DESCRIPTION
We needed suport for this API in our app where we avoid going back and forth to the FS to get the image data in Node. 
