### PR TITLE
Allow node to exit quickly by zeroing socket.io store timeout.

### DIFF
--- a/node-phantom.js
+++ b/node-phantom.js
@@ -131,6 +131,7 @@ module.exports={
 					case 'phantomExited':
 						request(socket,[0,'exitAck']);
 						server.close();
+						io.set('client store expiration', 0);
 						cmds[cmdId].cb();
 						delete cmds[cmdId];
 						break;


### PR DESCRIPTION
The default "client store expiration" timeout is 15 seconds, which keeps node from exiting.  This sets it to 0 when node-phantom knows it won't get any more responses.
