### PR TITLE
Prepare Socket.io before spawning PhantomJS.

### DIFF
--- a/node-phantom.js
+++ b/node-phantom.js
@@ -54,6 +54,8 @@ module.exports={
 			</script></head><body></body></html>');
 		}).listen();
 		
+		var io=socketio.listen(server,{'log level':1});
+
 		var port=server.address().port;
 		spawnPhantom(port,function(err,phantom){
 			if(err){
@@ -72,8 +74,6 @@ module.exports={
 				cmds[cmdid]={cb:callback};
 				cmdid++;
 			}
-		
-			var io=socketio.listen(server,{'log level':1});
 		
 			io.sockets.on('connection',function(socket){
 				socket.on('res',function(response){


### PR DESCRIPTION
Attaches Socket.io immediately to the node-phantom HTTP server,
instead of doing so later in the spawnPhantom callback.

A race condition can occur if PhantomJS is started and visits the
node-phantom control page before Socket.io was setup to serve on
node-phantom's server. If PhantomJS is fast enough, it will attempt
to fetch socket.io.js as a script but instead will recieve the
referring page's HTML as the script, causing PhantomJS to emit
a "Parse error" for the bogus script.
