### PR TITLE
Handling PhantomJS crash.

### DIFF
--- a/node-phantom.js
+++ b/node-phantom.js
@@ -191,6 +191,9 @@ module.exports={
                     },                 
 					exit:function(callback){
 						request(socket,[0,'exit'],callbackOrDummy(callback));
+					},
+					on: function(){
+						phantom.on.apply(phantom, arguments);
 					}
 				};
 			

--- a/node-phantom.js
+++ b/node-phantom.js
@@ -196,6 +196,17 @@ module.exports={
 			
 				callback(null,proxy);
 			});
+
+			// An exit event listener that is registered AFTER the phantomjs process
+			// is successfully created.
+			phantom.on('exit', function(code, signal){
+
+				// Close server upon phantom crash.
+				if(code !== 0 && signal === null){
+					console.warn('phantom crash: code '+code);
+					server.close();
+				}
+			});
 		});
 	}
 };


### PR DESCRIPTION
I have encountered several PhantomJS crashes.

The crash causes aborted children processes and the corresponding http server is never closed. This blocks the script from exiting normally.

In commit `#2038394` The phantom process's exit event is handled. Though there exists another process exit event handler (in `module.exports.create`), but it was meant for detecting spawning failure. Therefore I added my own exit event handler in the callback of the `spawnPhantom` method.

In commit `#f6fec47` I expose the child process's `on` method to the phantom proxy, enabling the developers to handle the child process events.
