### PR TITLE
Fixed page.includeJs()

### DIFF
--- a/bridge.js
+++ b/bridge.js
@@ -83,8 +83,9 @@ controlpage.onAlert=function(msg){
 			respond([id,cmdId,'pageJsInjected',JSON.stringify(result)]);
 			break;
 		case 'pageIncludeJs':
-			page.includeJs(request[3]);
-			respond([id,cmdId,'pageJsIncluded']);
+			page.includeJs(request[3], function(){
+				respond([id,cmdId,'pageJsIncluded']);
+			});
 			break;
 		case 'pageSendEvent':
 			page.sendEvent(request[3],request[4],request[5]);


### PR DESCRIPTION
In the current implementation of node-phantom a call to `page.includeJs()` returns immediately.
According to the [PhantomJS API](https://github.com/ariya/phantomjs/wiki/API-Reference-WebPage#wiki-webpage-includeJs) it invokes a callback, after the script has been loaded and executed.

I fixed `bridge.js` to respond in that callback.
