### PR TITLE
Remove unwrapArray

### DIFF
--- a/node-phantom.js
+++ b/node-phantom.js
@@ -8,9 +8,6 @@ function callbackOrDummy(callback){
 	if(callback===undefined)callback=function(){};
 	return callback;
 }
-function unwrapArray(arr) {
-	return arr && arr.length == 1 ? arr[0] : arr
-}
 
 module.exports={
 	create:function(callback,options){
@@ -177,7 +174,7 @@ module.exports={
 					var id = request[0];
 					var cmd = request[1];
 					var callback = callbackOrDummy(pages[id] ? pages[id][cmd] : undefined);
-					callback(unwrapArray(request[2]));
+					callback.apply(null, request[2]);
 				});
 				var proxy={
 					createPage:function(callback){					

--- a/test/testpagepushnotifications.js
+++ b/test/testpagepushnotifications.js
@@ -21,14 +21,14 @@ exports.testPhantomPagePushNotifications = function(beforeExit,assert) {
 				},errOr(function() {
 					//console.log(events);
 					assert.eql(events.onLoadStarted.length, 1);
-					assert.eql(events.onUrlChanged,[url]);
+					assert.eql(events.onUrlChanged,[[url]]);
 					assert.eql(events.onResourceRequested.length, 1);
 					assert.eql(events.onResourceReceived.length, 2);
-					assert.eql(events.onResourceReceived[0].stage, 'start');
-					assert.eql(events.onResourceReceived[1].stage, 'end');
+					assert.eql(events.onResourceReceived[0][0].stage, 'start');
+					assert.eql(events.onResourceReceived[1][0].stage, 'end');
 
-					assert.eql(events.onCallback, [{ msg: "callPhantom" }]);
-					assert.eql(events.onConsoleMessage, ['POW', 'WOW']);
+					assert.eql(events.onCallback, [[{ msg: "callPhantom" }]]);
+					assert.eql(events.onConsoleMessage, [['POW'], ['WOW']]);
 
 					assert.eql(events.onError.length, 1);
 					assert.eql(events.onError[0].length, 2);
@@ -41,7 +41,7 @@ exports.testPhantomPagePushNotifications = function(beforeExit,assert) {
 						console.log(a);
 						console.log(b);
 					}, errOr(function(){
-						assert.eql(events.onConsoleMessage, ['A', 'B']);
+						assert.eql(events.onConsoleMessage, [['A'], ['B']]);
 
 						ph.createPage(errOr(function(page){
 							page.onLoadFinished = function(){
@@ -64,16 +64,16 @@ exports.testPhantomPagePushNotifications = function(beforeExit,assert) {
 	function registerCallbacks(page) {
 		var events = {};
 		var callbacks = [
-      'onAlert','onConfirm','onConsoleMessage','onError', 'onInitialized',/*'onLoadFinished',*/
-      'onLoadStarted','onPrompt', 'onResourceRequested','onResourceReceived','onUrlChanged',
-      'onCallback'
-    ];
+		                 'onAlert','onConfirm','onConsoleMessage','onError', 'onInitialized',/*'onLoadFinished',*/
+		                 'onLoadStarted','onPrompt', 'onResourceRequested','onResourceReceived','onUrlChanged',
+		                 'onCallback'
+		];
 		callbacks.forEach(function(cb) {
 			page[cb] = function(evt) {
 				if (!events[cb]) events[cb] = [];
-				events[cb].push(evt);
-			}
-		})
+				events[cb].push(Array.prototype.slice.call(arguments));
+			};
+		});
 		return events;
 	}
 
@@ -81,6 +81,6 @@ exports.testPhantomPagePushNotifications = function(beforeExit,assert) {
 		return function(err, res) {
 			assert.ifError(err);
 			fn(res);
-		}
+		};
 	}
 };


### PR DESCRIPTION
This caused API of page.onResourceRequested to change with phantom
1.9.0 (first argument was `request`, it became an array [`request`,
`networkRequest`]).

Now use fn.apply to pass arguments as they are received. This ensure
that any change in phantomjs is transparently reflected without
interference from node-phantom.

NOTE: This change the API of onError and onPrompt which where already
affected by this bug. They now get the same parameters as described on
https://github.com/ariya/phantomjs/wiki/API-Reference-WebPage.
