### PR TITLE
expose phantomjs child process

### DIFF
--- a/node-phantom.js
+++ b/node-phantom.js
@@ -191,7 +191,9 @@ module.exports={
                     },                 
 					exit:function(callback){
 						request(socket,[0,'exit'],callbackOrDummy(callback));
-					}
+					},
+
+					_phantom: phantom
 				};
 			
 				callback(null,proxy);

--- a/test/testcreatephantom.js
+++ b/test/testcreatephantom.js
@@ -1,0 +1,9 @@
+var phantom=require('../node-phantom');
+
+exports.testPhantomCreate=function(beforeExit,assert) {
+  phantom.create(function(error,ph){
+    assert.ok(ph._phantom.constructor.toString().match('function ChildProcess()'));
+    assert.ok(ph._phantom.pid > 0);
+    ph.exit();
+  });
+};


### PR DESCRIPTION
I had to get phantomjs child_process's pid for some monitoring purpose. But it is not exposed.
So I exposed it. see example below

``` js
  phantom.create(function(error,ph){
    console.log(ph._phantom.pid); //print the pid
    ph.exit();
  });
```
