### PR TITLE
Better handling of phantom crashes

### DIFF
--- a/node-phantom.js
+++ b/node-phantom.js
@@ -32,16 +32,15 @@ module.exports={
 			phantom.stderr.on('data',function(data){
 				return console.warn('phantom stderr: '+data);
 			});
-			var hasErrors = false;
-			var onError = function () {
-				hasErrors = true;
-			}
-			phantom.on('error', onError);
-			phantom.on('exit', onError);
+			var exitCode=0;
+			phantom.on('error',function(){
+				exitCode=-1;
+			});
+			phantom.on('exit',function(code){
+				exitCode=code;
+			});
 			setTimeout(function(){ //wait a bit to see if the spawning of phantomjs immediately fails due to bad path or similar
-				phantom.removeListener('error', onError);
-				phantom.removeListener('exit', onError);
-				callback(hasErrors, phantom);
+				callback(exitCode!==0,phantom);
 			},100);
 		}
 		

--- a/node-phantom.js
+++ b/node-phantom.js
@@ -197,6 +197,7 @@ module.exports={
 						request(socket,[0,'addCookie', cookie],callbackOrDummy(callback));
 					},
 					exit:function(callback){
+						phantom.removeListener('exit', crash);
 						request(socket,[0,'exit'],callbackOrDummy(callback));
 					},
 					on: function(){
@@ -210,14 +211,12 @@ module.exports={
 
 			// An exit event listener that is registered AFTER the phantomjs process
 			// is successfully created.
-			phantom.on('exit', function(code, signal){
-
+			var crash = function(code, signal){
 				// Close server upon phantom crash.
-				if(code !== 0 && signal === null){
-					console.warn('phantom crash: code '+code);
-					server.close();
-				}
-			});
+				console.warn('phantom crash: code '+code+', signal '+signal);
+				server.close();
+			};
+			phantom.on('exit', crash);
 		});
 	}
 };

--- a/node-phantom.js
+++ b/node-phantom.js
@@ -32,15 +32,16 @@ module.exports={
 			phantom.stderr.on('data',function(data){
 				return console.warn('phantom stderr: '+data);
 			});
-			var exitCode=0;
-			phantom.on('error',function(){
-				exitCode=-1;
-			});
-			phantom.on('exit',function(code){
-				exitCode=code;
-			});
+			var hasErrors = false;
+			var onError = function () {
+				hasErrors = true;
+			}
+			phantom.on('error', onError);
+			phantom.on('exit', onError);
 			setTimeout(function(){ //wait a bit to see if the spawning of phantomjs immediately fails due to bad path or similar
-				callback(exitCode!==0,phantom);
+				phantom.removeListener('error', onError);
+				phantom.removeListener('exit', onError);
+				callback(hasErrors, phantom);
 			},100);
 		}
 		


### PR DESCRIPTION
Previous code was checking for `code !== 0 && signal === null`. When phantomjs crash on my machine (debian testing, phantom 1.8.2), `code` is `0` and `signal` is `SIGSEGV`.

New code is more pragmatic. If phantom exit for any reason, we need to shutdown the server.
