### PR TITLE
Allow setting of phantom viewport size

### DIFF
--- a/bridge.js
+++ b/bridge.js
@@ -123,7 +123,7 @@ controlpage.onAlert=function(msg){
 			page[request[3]] = eval('(' + request[4] + ')')
 			break;
 		case 'pageSetViewport':
-			page.viewportSize = {width:request[3], height:request[4]}
+			page.viewportSize = {width:request[3], height:request[4]};
 			break;
 		default:
 			console.error('unrecognized request:'+request);

--- a/bridge.js
+++ b/bridge.js
@@ -124,6 +124,7 @@ controlpage.onAlert=function(msg){
 			break;
 		case 'pageSetViewport':
 			page.viewportSize = {width:request[3], height:request[4]};
+			respond([id,cmdId,'pageSetViewportDone']);
 			break;
 		default:
 			console.error('unrecognized request:'+request);

--- a/bridge.js
+++ b/bridge.js
@@ -122,6 +122,9 @@ controlpage.onAlert=function(msg){
 		case 'pageSetFn':
 			page[request[3]] = eval('(' + request[4] + ')')
 			break;
+		case 'pageSetViewport':
+			page.viewportSize = {width:request[3], height:request[4]}
+			break;
 		default:
 			console.error('unrecognized request:'+request);
 			break;

--- a/node-phantom.js
+++ b/node-phantom.js
@@ -175,6 +175,7 @@ module.exports={
 					case 'pageRendered':
 					case 'pageEventSent':
 					case 'pageFileUploaded':
+					case 'pageSetViewportDone':
 					case 'pageEvaluatedAsync':
 						cmds[cmdId].cb(null);
 						delete cmds[cmdId];

--- a/node-phantom.js
+++ b/node-phantom.js
@@ -169,6 +169,7 @@ module.exports={
 					case 'pageClosed':
 						delete pages[id]; // fallthru
 					case 'pageSetDone':
+					case 'pageSetViewportDone':
 					case 'pageJsIncluded':
 					case 'cookieAdded':
 					case 'pageRendered':

--- a/node-phantom.js
+++ b/node-phantom.js
@@ -117,7 +117,7 @@ module.exports={
 							evaluate:function(evaluator,callback){
 								request(socket,[id,'pageEvaluate',evaluator.toString()].concat(Array.prototype.slice.call(arguments,2)),callbackOrDummy(callback));
 							},
-                            evaluateAsync:function(evaluator,callback){
+							evaluateAsync:function(evaluator,callback){
 								request(socket,[id,'pageEvaluateAsync',evaluator.toString()].concat(Array.prototype.slice.call(arguments,2)),callbackOrDummy(callback));
 							},
 							set:function(name,value,callback){
@@ -128,6 +128,9 @@ module.exports={
 							},
 							setFn: function(pageCallbackName, fn, callback) {
 								request(socket, [id, 'pageSetFn', pageCallbackName, fn.toString()], callbackOrDummy(callback));
+							},
+							setViewport: function(viewport, fn, callback) {
+								request(socket, [id, 'pageSetViewport', viewport.width, viewport.height], callbackOrDummy(callback));
 							}
 						};
 						pages[id] = pageProxy;

--- a/node-phantom.js
+++ b/node-phantom.js
@@ -129,7 +129,7 @@ module.exports={
 							setFn: function(pageCallbackName, fn, callback) {
 								request(socket, [id, 'pageSetFn', pageCallbackName, fn.toString()], callbackOrDummy(callback));
 							},
-							setViewport: function(viewport, fn, callback) {
+							setViewport: function(viewport, callback) {
 								request(socket, [id, 'pageSetViewport', viewport.width, viewport.height], callbackOrDummy(callback));
 							}
 						};

--- a/package.json
+++ b/package.json
@@ -12,8 +12,12 @@
   "scripts": {
     "test": "mocha"
   },
-  "dependencies": {"socket.io": ">=0.9.6"},
-  "devDependencies": {"socket.io": ">=0.9.2"},
+  "dependencies": {
+    "socket.io": ">=0.9.6"
+  },
+  "devDependencies": {
+     "mocha": "*"
+  },
   "optionalDependencies": {},
   "engines": {
     "node": "*"

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "socket.io": ">=0.9.6"
   },
   "devDependencies": {
-     "mocha": "*"
+     "mocha": "*",
+     "pngjs": "0.4.0"
   },
   "optionalDependencies": {},
   "engines": {

--- a/test/pagesetviewport.js
+++ b/test/pagesetviewport.js
@@ -1,0 +1,42 @@
+var http=require('http');
+var phantom=require('../node-phantom');
+var assert=require('assert');
+
+var server;
+var testPage;
+
+describe('Phantom Page',function(){
+  describe('setting viewport',function(){
+    this.timeout(5000);
+    before(function(done){
+      server = http.createServer(function(request,response){
+        response.end('<html><body>Hello</body></html>')
+      }).listen();
+
+      phantom.create(function(error,ph){
+        assert.ifError(error);
+        ph.createPage(function(err,page){
+          assert.ifError(err);
+          page.open('http://localhost:'+server.address().port, function(err,status) {
+            assert.ifError(err);
+            assert.equal(status,'success');
+            testPage = page;
+            done()
+          });
+        });
+      });
+    });
+
+    it('should invoke the callback',function(done){
+      testPage.setViewport({width: 20, height: 30}, function(err) {
+        assert.ifError(err);
+        done()
+      });
+    });
+
+    after(function() {
+      server.close();
+      testPage = server = null;
+    });
+  });
+});


### PR DESCRIPTION
Adds a setViewport function to page that takes an object with width and height (in pixels):

`page.setViewport({width: 1280, height: 1024});`

This is useful if you are capturing screenshots of test failures.
