### PR TITLE
Fixes error accoring to node's API reference

### DIFF
--- a/node-phantom.js
+++ b/node-phantom.js
@@ -59,8 +59,7 @@ module.exports={
 		
 		var io=socketio.listen(server,{'log level':1});
 
-		var port=server.address().port;
-		spawnPhantom(port,function(err,phantom){
+		var listen = function(err,phantom){
 			if(err){
 				server.close();
 				callback(true);
@@ -218,6 +217,11 @@ module.exports={
 					server.close();
 				}
 			});
+		};
+
+		server.on('listening', function() {
+			var port=server.address().port;
+			spawnPhantom(port, listen);
 		});
 	}
 };

--- a/node-phantom.js
+++ b/node-phantom.js
@@ -59,7 +59,7 @@ module.exports={
 		
 		var io=socketio.listen(server,{'log level':1});
 
-		var listen = function(err,phantom){
+		var talk = function(err,phantom){
 			if(err){
 				server.close();
 				callback(true);
@@ -221,7 +221,7 @@ module.exports={
 
 		server.on('listening', function() {
 			var port=server.address().port;
-			spawnPhantom(port, listen);
+			spawnPhantom(port, talk);
 		});
 	}
 };


### PR DESCRIPTION
I was getting the following error:

```
TypeError: Cannot read property 'port' of null
    at Object.module.exports.create (/home/emilsedgh/node_modules/node-phantom/node-phantom.js:62:28)
```

According to [0], server.address() should only be called after server emits 'listening' event.
