### PR TITLE
Added a page.post function

### DIFF
--- a/bridge.js
+++ b/bridge.js
@@ -74,6 +74,14 @@ controlpage.onAlert=function(msg){
 				respond([id, cmdId, 'pageOpened', status]);
 			});
 			break;
+		case 'pagePost':
+			page.open(request[3], 'post', request[4]);
+			break;
+		case 'pagePostWithCallback':
+			page.open(request[3], 'post', request[4], function(status){
+				respond([id, cmdId, 'pageOpened', status]);
+			});
+			break;
 		case 'pageClose':
 			page.close();
 			respond([id,cmdId,'pageClosed']);

--- a/node-phantom.js
+++ b/node-phantom.js
@@ -92,6 +92,13 @@ module.exports={
 										request(socket, [id, 'pageOpenWithCallback', url], callback);
 									}
 								},
+								post:function(url, data, callback){
+									if(callback === undefined){
+										request(socket, [id, 'pagePost', url, data]);
+									}else{
+										request(socket, [id, 'pagePostWithCallback', url, data], callback);
+									}
+								},
 								close:function(callback){
 									request(socket,[id,'pageClose'],callbackOrDummy(callback));
 								},

--- a/test/testpagepost.js
+++ b/test/testpagepost.js
@@ -1,0 +1,23 @@
+var http=require('http');
+var phantom=require('../node-phantom');
+
+var server=http.createServer(function(request,response){
+	response.writeHead(200,{"Content-Type": "text/html"});
+	response.end('<html><head></head><body>Hello World</body></html>');
+}).listen();
+
+exports.testPhantomPageOpen=function(beforeExit,assert){
+	phantom.create(function(error,ph){
+		assert.ifError(error);
+		ph.createPage(function(err,page){
+			assert.ifError(err);
+			var data = "test=test";
+			page.post('http://localhost:'+server.address().port,data,function(err,status){
+				assert.ifError(err);
+				assert.equal(status,'success');
+				server.close();
+				ph.exit();
+			});
+		});
+	});
+};


### PR DESCRIPTION
I needed to access a page using the post action for authentication, so I added a page.post function that calls Phantom's open(url,'post',data,callback). I thought I could share it in case someone else needs it.

Definition :
page.post(url, data[, callback])
    url : where to post
    data : html encoded string with the body of the request 
    callback : callback function (optional)

Example code :
var phantom=require('node-phantom');
phantom.create(function(error,ph){
    ph.createPage(function(err,page){
        var data = "email=test@domain.com&pass=my_pass";
        page.post('http://domain.com/login',data,function(err,status){
            //Do stuff here
        });
    });
});
