### PR TITLE
Added setPaperSize functionality

### DIFF
--- a/bridge.js
+++ b/bridge.js
@@ -129,6 +129,10 @@ controlpage.onAlert=function(msg){
 			page.viewportSize = {width:request[3], height:request[4]};
 			respond([id,cmdId,'pageSetViewportDone']);
 			break;
+		case 'pageSetPaperSize':
+			page.paperSize = request[3];
+			respond([id,cmdId,'pageSetPaperSizeDone']);
+			break;
 		default:
 			console.error('unrecognized request:'+request);
 			break;

--- a/node-phantom.js
+++ b/node-phantom.js
@@ -177,6 +177,7 @@ module.exports={
 						case 'pageEventSent':
 						case 'pageFileUploaded':
 						case 'pageSetViewportDone':
+						case 'pageSetPaperSizeDone':
 						case 'pageEvaluatedAsync':
 							cmds[cmdId].cb(null);
 							delete cmds[cmdId];

--- a/node-phantom.js
+++ b/node-phantom.js
@@ -130,6 +130,9 @@ module.exports={
 								},
 								setViewport: function(viewport, callback) {
 									request(socket, [id, 'pageSetViewport', viewport.width, viewport.height], callbackOrDummy(callback));
+								},
+								setPaperSize: function(paperSize, callback) {
+									request(socket, [id, 'pageSetPaperSize', paperSize], callbackOrDummy(callback));
 								}
 							}
 							pages[id] = pageProxy;


### PR DESCRIPTION
Thank you for this very clean and clear node-plug-in.  I found support for `setViewport`, but no support for `setPaperSize`, which is necessary for rendering PDFs with PhantomJS.

I added `setPaperSize(obj)`, where `obj` is identical to `page.paperSize` described at http://phantomjs.org/api/webpage/property/paper-size.html.
