### PR TITLE
node-phantom calling twice the phantom create callback

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "test": "mocha"
   },
   "dependencies": {
-    "socket.io": ">=0.9.6"
+    "socket.io": "0.9.x"
   },
   "devDependencies": {
      "mocha": "*",


### PR DESCRIPTION
Hi,

Just found a weird behaviour with node-phantom when creating a process.
After calling phantom.create with a callback, after a number of interactions creating and closing pages the callback provided to phantom.create function is executed again.

After digging around with this, I think I found the reason why this happen and here's the fix.

You can find a more detailed description about the bug here: https://github.com/apdmatos/node-phantom-connectionupgrade-bug

And there's a script to reproduce it as well.

For some reason, this does not work with socketio version 1.x.x or higher. So, I've just updated the package.json till someone figure out what is going on with this.

Regards,
André 
