### PR TITLE
Socket.io version is not compatible anymore

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Alex Scheel Meyer (http://www.linkedin.com/in/alexscheelmeyer)",
   "name": "node-phantom",
   "description": "bridge between node.js and PhantomJS",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "homepage": "https://github.com/alexscheelmeyer/node-phantom",
   "repository": {
     "type": "git",
@@ -13,7 +13,7 @@
     "test": "mocha"
   },
   "dependencies": {
-    "socket.io": ">=0.9.6"
+    "socket.io": "0.9.6"
   },
   "devDependencies": {
      "mocha": "*",


### PR DESCRIPTION
For some reason, the socket IO '1.0.6' version is not compatible
anymore. I am hard setting the version to be 0.9.6.
