### PR TITLE
using system.args instead of phantom.args

### DIFF
--- a/bridge.js
+++ b/bridge.js
@@ -1,6 +1,6 @@
 //Released to the public domain.
-
-var port=phantom.args[0];
+var system = require('system');
+var port=system.args[1];
 var webpage=require('webpage');
 var controlpage=webpage.create();
 


### PR DESCRIPTION
phantomjs has removed phantom.args, instead system.args should be used